### PR TITLE
Shorten the waiting time until inference

### DIFF
--- a/mozc-nazoru/src/nazoru/keyboard_recorder.py
+++ b/mozc-nazoru/src/nazoru/keyboard_recorder.py
@@ -159,7 +159,7 @@ class KeyboardRecorderFromEvdev(KeyboardRecorder):
       52: '.',
       53: '/'
   }
-  WAIT_SECONDS = 2
+  WAIT_SECONDS = 0.5
 
   def __init__(self, verbose=False):
     if evdev is None:


### PR DESCRIPTION
This makes the waiting time for KeyboardRecorderFromEvdev shorter. It matches the time for KeyboardRecorderFromConsole.