### PR TITLE
Remove wiringpi from OSX dependency

### DIFF
--- a/mozc-nazoru/setup.py
+++ b/mozc-nazoru/setup.py
@@ -68,6 +68,6 @@ setup(
         'enum34;python_version<"3.4"',
         'pyserial',
         'evdev;platform_system=="Linux"',
-        'wiringpi'
+        'wiringpi;platform_system=="Linux"'
     ]
   )


### PR DESCRIPTION
Removing wiringpi module from dependency for OSX since this causes error when being installed on Mac.