### PR TITLE
Update mozc-caps.ino

### DIFF
--- a/mozc-caps/firmware/mozc-caps/mozc-caps.ino
+++ b/mozc-caps/firmware/mozc-caps/mozc-caps.ino
@@ -46,7 +46,13 @@ const char* characters[] = {"a", "b", "c", "d", "e", "f", "g", "h", "i",
 class Compositor {
  public:
   Compositor() : last_character_unsettled_(false) {}
-  // TODO: add commit() which commits the Japanese composition by Enter key.
+  // Commit the current composition by sending a newline character.
+  void commit() {
+      if (last_character_unsettled_) {
+          bleKeyboard.write('\n');
+          last_character_unsettled_ = false;
+      }
+  }
   void enter();
   void select(const char* str);
 


### PR DESCRIPTION
Implement the commit() function within the Compositor class. This function is designed to finalize the Japanese composition process by simulating the pressing of the Enter key, effectively submitting the composed text.